### PR TITLE
Yearly progress compare

### DIFF
--- a/src/components/primary_footer.js
+++ b/src/components/primary_footer.js
@@ -5,7 +5,7 @@ export default function Primary_Footer() {
 
     return (
         <header className={footer_styles.primary_footer}>
-            <p>Footer</p>
+            <p>Built by SG for Bear Cobble Sugarworks 2023</p>
             <p></p>
         </header>
     )

--- a/src/pages/production.js
+++ b/src/pages/production.js
@@ -1,0 +1,144 @@
+//Libraries
+import mysql from 'mysql2';
+import { useEffect, useState } from 'react';
+//Styles
+import production_styles from '@/styles/production_page_styles.module.scss';
+//Functions
+import { formatTime } from '@/utils/formatDate';
+
+
+//get all production data from db
+export async function getServerSideProps(){
+    let productionYears = [2023, 2022];
+    let productionData = [];
+    const pool = mysql.createPool({
+        host: process.env.MYSQL_DB_HOST,
+        user: process.env.MYSQL_DB_USER,
+        password: process.env.MYSQL_DB_PASSWORD,
+        database: process.env.MYSQL_DB_NAME
+}).promise();
+for(let i=0; i < productionYears.length; i++){
+    let returnedResults = await pool.query(`select barrel_id, drum_number, gallons from production${productionYears[i]} order by barrel_id`);
+    returnedResults = await JSON.parse(JSON.stringify(returnedResults[0]));
+    productionData.push(returnedResults);
+}
+ return ({props: {productionData: productionData}})
+
+}
+
+//sort into object with dates (jan, 01 etc) an associated produciton totals
+//build an object with dates as keys and object containing yearly info ex
+// Jan 01 12:00 : { 2018: [production in time period, running total], 2019: [production in time period: running total] etc}
+
+// take array of data and find the earliest and last dates
+function findStartAndFinishDates(dataArray){
+    let absoluteMinMax = [];
+    let yearlyMinMax = [];
+    dataArray.forEach(innerArray=> {
+        let minDate = formatTime(new Date(innerArray[0].barrel_id))
+        let minRelative = minDate.month+minDate.day;
+        let maxDate = formatTime(new Date(innerArray[innerArray.length-1].barrel_id))
+        let maxRelative = maxDate.month+maxDate.day;
+        yearlyMinMax.push(minRelative)
+        yearlyMinMax.push(maxRelative)
+        yearlyMinMax.sort();
+    });
+    absoluteMinMax[0]=yearlyMinMax[0];
+    absoluteMinMax[1]=yearlyMinMax[yearlyMinMax.length-1];
+    return absoluteMinMax;
+}
+
+function buildEmptyChronologicObject(minMax){
+    let chronologicObj ={};
+    //format as MM-DD HH:MM
+    let startDate =  new Date(`00/${minMax[0].slice(0,2)}/${minMax[0].slice(2,4)}`);
+    let endDate =  new Date(`00/${minMax[1].slice(0,2)}/${minMax[1].slice(2,4)}`);
+    let curDate = startDate;
+    while(curDate < endDate){
+        let tempDate = formatTime(curDate);
+        chronologicObj[`${tempDate.month}/${tempDate.day} ${tempDate.time24Hr}`] = {}
+        curDate = new Date(curDate.setHours(curDate.getHours()+8))
+    }
+    return(chronologicObj)
+}
+
+
+function populateChronologicObject(emptyChronologicObj, sourceData){
+    let timeStamps = Object.keys(emptyChronologicObj);
+    for(let sourceIndex = 0; sourceIndex < sourceData.length; sourceIndex++){
+        let currentYearData = sourceData[sourceIndex]
+        for(let dataIndex = 0; dataIndex < currentYearData.length; dataIndex++){
+            let currentProductionRecord = currentYearData[dataIndex]
+            let currentProductionDate = new Date(currentProductionRecord.barrel_id)
+            let formattedProductionDate = new Date(currentProductionDate.setFullYear(2000));
+            let foundIndex = timeStamps.findIndex(timeStamp => {
+                let compareTimeStamp = new Date(timeStamp)
+                compareTimeStamp.setFullYear(2000);
+                return Date.parse(formattedProductionDate) < Date.parse(compareTimeStamp)
+            })
+            console.log(timeStamps[foundIndex])
+            emptyChronologicObj[timeStamps[foundIndex]] = {test: 0}
+        }
+    }
+}
+
+function makeProductionBars() {
+    let years = [[2023, 0], [2022, 0], [2021, 0], [2020, 0], [2019, 0], [2018, 0]];
+    let records = {};
+    
+    for (let i = 0; i < 10; i++) {
+        records[i] = {};
+        years.forEach(year => {
+            records[i][year[0]] = year[1]
+            year[1] = Math.round(Math.random() * 10) + year[1]
+        })
+    }
+    
+    return records;
+}
+
+const records = makeProductionBars();
+
+export default function Produciton({productionData}) {
+    console.log(productionData)
+    const[sortedOrderedData, setSortedOrderedData] = useState(buildEmptyChronologicObject( findStartAndFinishDates(productionData)))
+    populateChronologicObject(sortedOrderedData, productionData)
+    console.log(sortedOrderedData)
+
+    const [advance, setadvance] = useState(0)
+    const [currentRecordIndex, setCurrentRecordIndex] = useState(0);
+    const [dataDivs, setDataDivs] = useState([]);
+
+    useEffect(() => {
+        function makeDataDivs() {
+            setDataDivs([])
+            let tempArray = [];
+            let currentRecords = records[currentRecordIndex]
+            for (let year in currentRecords) {
+                tempArray.push(<div key={`${currentRecords[year]}-${year}`} className={production_styles.yearly_row}>
+                    <h2>{year}</h2>
+                    <div style={{ width: `${currentRecords[year] * 4}px` }} className={production_styles.progress_bar}></div>
+                    <p>{currentRecords[year]}</p>
+                </div>)
+            }
+            setDataDivs(tempArray.reverse())
+            setCurrentRecordIndex(prev => {
+                return prev + 1
+            });
+
+        }
+        makeDataDivs()
+    }, [advance])
+
+
+
+    return (
+        <>
+            <button onClick={()=>setadvance(prev => prev+1)}>Advance</button>
+            <div className={production_styles.production_animation_container}>
+                {dataDivs}
+            </div>
+
+        </>
+    )
+}

--- a/src/pages/production.js
+++ b/src/pages/production.js
@@ -7,8 +7,9 @@ import production_styles from '@/styles/production_page_styles.module.scss';
 import { formatTime } from '@/utils/formatDate';
 
 
-//get all production data from db
-export async function getServerSideProps(){
+//get all production data from db and pass it as a prop to main compoenent
+//be sure the production data is sorted chronologically
+export async function getServerSideProps() {
     let productionYears = [2023, 2022];
     let productionData = [];
     const pool = mysql.createPool({
@@ -16,76 +17,117 @@ export async function getServerSideProps(){
         user: process.env.MYSQL_DB_USER,
         password: process.env.MYSQL_DB_PASSWORD,
         database: process.env.MYSQL_DB_NAME
-}).promise();
-for(let i=0; i < productionYears.length; i++){
-    let returnedResults = await pool.query(`select barrel_id, drum_number, gallons from production${productionYears[i]} order by barrel_id`);
-    returnedResults = await JSON.parse(JSON.stringify(returnedResults[0]));
-    productionData.push(returnedResults);
-}
- return ({props: {productionData: productionData}})
+    }).promise();
+    for (let i = 0; i < productionYears.length; i++) {
+        let returnedResults = await pool.query(`select barrel_id, drum_number, gallons from production${productionYears[i]} order by barrel_id`);
+        returnedResults = await JSON.parse(JSON.stringify(returnedResults[0]));
+        productionData.push(returnedResults);
+    }
+    return ({ props: { productionData: productionData } })
 
 }
 
-//sort into object with dates (jan, 01 etc) an associated produciton totals
-//build an object with dates as keys and object containing yearly info ex
-// Jan 01 12:00 : { 2018: [production in time period, running total], 2019: [production in time period: running total] etc}
 
-// take array of data and find the earliest and last dates
-function findStartAndFinishDates(dataArray){
+
+// take array of data (also arrays) and find the chronologically first and last dates
+// inner arrays of the data array must be sorted chronologically
+function findStartAndFinishDates(dataArray) {
     let absoluteMinMax = [];
     let yearlyMinMax = [];
-    dataArray.forEach(innerArray=> {
+    dataArray.forEach(innerArray => {
         let minDate = formatTime(new Date(innerArray[0].barrel_id))
-        let minRelative = minDate.month+minDate.day;
-        let maxDate = formatTime(new Date(innerArray[innerArray.length-1].barrel_id))
-        let maxRelative = maxDate.month+maxDate.day;
+        let minRelative = minDate.month + minDate.day;
+        let maxDate = formatTime(new Date(innerArray[innerArray.length - 1].barrel_id))
+        let maxRelative = maxDate.month + maxDate.day;
         yearlyMinMax.push(minRelative)
         yearlyMinMax.push(maxRelative)
         yearlyMinMax.sort();
     });
-    absoluteMinMax[0]=yearlyMinMax[0];
-    absoluteMinMax[1]=yearlyMinMax[yearlyMinMax.length-1];
+    absoluteMinMax[0] = yearlyMinMax[0];
+    absoluteMinMax[1] = yearlyMinMax[yearlyMinMax.length - 1];
     return absoluteMinMax;
 }
 
-function buildEmptyChronologicObject(minMax){
-    let chronologicObj ={};
-    //format as MM-DD HH:MM
-    let startDate =  new Date(`00/${minMax[0].slice(0,2)}/${minMax[0].slice(2,4)}`);
-    let endDate =  new Date(`00/${minMax[1].slice(0,2)}/${minMax[1].slice(2,4)}`);
+//Build an empty object with keys containing date + times, incrementing by 8 hour intervals (or whatever amount we want to adjust by)
+//The first and last date/time will be dictated by the minMax array arguement minMax[0] being our start date & time minMax[1] being our end date and time
+//This object will be later populated by the production data.
+function buildEmptyChronologicObject(minMax) {
+    let chronologicObj = {};
+    let intervalDuration = 8;
+    //format as MM-DD HH:MM - formatting the year to be 00 or 2000 so we can compare all years based on month and day
+    let startDate = new Date(`00/${minMax[0].slice(0, 2)}/${minMax[0].slice(2, 4)}`);
+    let endDate = new Date(`00/${minMax[1].slice(0, 2)}/${minMax[1].slice(2, 4)}`);
+    let paddedEndDate = new Date(Date.parse(endDate) + 172800000)
     let curDate = startDate;
-    while(curDate < endDate){
+    while (curDate < paddedEndDate) {
         let tempDate = formatTime(curDate);
         chronologicObj[`${tempDate.month}/${tempDate.day} ${tempDate.time24Hr}`] = {}
-        curDate = new Date(curDate.setHours(curDate.getHours()+8))
+        curDate = new Date(curDate.setHours(curDate.getHours() + intervalDuration))
     }
-    return(chronologicObj)
+    return (chronologicObj)
 }
 
 
-function populateChronologicObject(emptyChronologicObj, sourceData){
-    let timeStamps = Object.keys(emptyChronologicObj);
-    for(let sourceIndex = 0; sourceIndex < sourceData.length; sourceIndex++){
-        let currentYearData = sourceData[sourceIndex]
-        for(let dataIndex = 0; dataIndex < currentYearData.length; dataIndex++){
-            let currentProductionRecord = currentYearData[dataIndex]
-            let currentProductionDate = new Date(currentProductionRecord.barrel_id)
-            let formattedProductionDate = new Date(currentProductionDate.setFullYear(2000));
-            let foundIndex = timeStamps.findIndex(timeStamp => {
-                let compareTimeStamp = new Date(timeStamp)
-                compareTimeStamp.setFullYear(2000);
-                return Date.parse(formattedProductionDate) < Date.parse(compareTimeStamp)
-            })
-            console.log(timeStamps[foundIndex])
-            emptyChronologicObj[timeStamps[foundIndex]] = {test: 0}
+
+// take our empty object with chornologically ordered timestamps (arg1) and populate each time stamp with yearly production from our production data (arg2)
+// each year should have an array as a value with the first value being the amount produced in the given time period, and the second being the running YTD total
+// ex April 01 12:00 : { 2018: [production in time period, running total], 2019: [production in time period: running total] etc}
+function populateChronologicObject(emptyChronologicObj, sourceData) {
+    let timeStamps = Object.keys(emptyChronologicObj);  //array of our time stamps to cycle through
+    for (let sourceIndex = 0; sourceIndex < sourceData.length; sourceIndex++) { //cycling through our source data year by year
+        let currentYearData = sourceData[sourceIndex];
+        let currentYear = currentYearData[0].barrel_id.slice(0, 4);
+
+        let periodTotal = 0;
+        let ytdTotal = 0;
+
+        //cycle through timestamps one by one
+        //for each time stamp, check if there are production records younger or the same age as it, but older than the previous timestamp
+        //if so add them up, update the period total and YTD total, then move on to the next timestamp.  
+        //if not skip to the next timestamp and check again
+        //keep track of the most recently added production record index
+        let currentProductionRecordIndex = 0;
+        let currentProductionRecord = currentYearData[currentProductionRecordIndex];
+        let currentProductionDate = new Date(currentProductionRecord.barrel_id).setFullYear(2000)
+
+        let currentTimeStampIndex = 0;
+        let currentTimeStamp = timeStamps[currentTimeStampIndex]
+        let currentTimeStampDate = new Date(currentTimeStamp).setFullYear(2000)
+
+        while (currentTimeStampIndex < timeStamps.length) {
+
+            while (currentProductionDate > currentTimeStampDate && currentTimeStampIndex < timeStamps.length) {
+                emptyChronologicObj[timeStamps[currentTimeStampIndex]] = { ...emptyChronologicObj[timeStamps[currentTimeStampIndex]], [currentYear]: [periodTotal, ytdTotal] }
+                currentTimeStampIndex++
+                currentTimeStamp = timeStamps[currentTimeStampIndex]
+                currentTimeStampDate = new Date(currentTimeStamp).setFullYear(2000)
+
+            }
+
+            while (currentProductionDate <= currentTimeStampDate && currentProductionRecordIndex < currentYearData.length) {
+                periodTotal += currentProductionRecord.gallons;
+                ytdTotal += currentProductionRecord.gallons;
+                currentProductionRecordIndex++
+                if(currentProductionRecordIndex<currentYearData.length-1){
+                    currentProductionRecord = currentYearData[currentProductionRecordIndex];
+                    currentProductionDate = new Date(currentProductionRecord.barrel_id).setFullYear(2000)
+                }
+
+            }
+            emptyChronologicObj[timeStamps[currentTimeStampIndex]] = { ...emptyChronologicObj[timeStamps[currentTimeStampIndex]], [currentYear]: [periodTotal, ytdTotal] }
+            periodTotal = 0;
+            currentTimeStampIndex++
+
         }
+
+
     }
 }
 
 function makeProductionBars() {
     let years = [[2023, 0], [2022, 0], [2021, 0], [2020, 0], [2019, 0], [2018, 0]];
     let records = {};
-    
+
     for (let i = 0; i < 10; i++) {
         records[i] = {};
         years.forEach(year => {
@@ -93,15 +135,15 @@ function makeProductionBars() {
             year[1] = Math.round(Math.random() * 10) + year[1]
         })
     }
-    
+    console.log('records, ', records)
     return records;
 }
 
 const records = makeProductionBars();
 
-export default function Produciton({productionData}) {
-    console.log(productionData)
-    const[sortedOrderedData, setSortedOrderedData] = useState(buildEmptyChronologicObject( findStartAndFinishDates(productionData)))
+export default function Produciton({ productionData }) {
+    // console.log(productionData)
+    const [sortedOrderedData, setSortedOrderedData] = useState(buildEmptyChronologicObject(findStartAndFinishDates(productionData)))
     populateChronologicObject(sortedOrderedData, productionData)
     console.log(sortedOrderedData)
 
@@ -113,12 +155,15 @@ export default function Produciton({productionData}) {
         function makeDataDivs() {
             setDataDivs([])
             let tempArray = [];
-            let currentRecords = records[currentRecordIndex]
+            // let currentRecords = records[currentRecordIndex]
+            let currentRecords = sortedOrderedData[Object.keys(sortedOrderedData)[currentRecordIndex]]
+            console.log(currentRecordIndex)
             for (let year in currentRecords) {
+                console.log(year)
                 tempArray.push(<div key={`${currentRecords[year]}-${year}`} className={production_styles.yearly_row}>
                     <h2>{year}</h2>
-                    <div style={{ width: `${currentRecords[year] * 4}px` }} className={production_styles.progress_bar}></div>
-                    <p>{currentRecords[year]}</p>
+                    <div style={{ width: `${currentRecords[year][1]/18886*100}%` }} className={production_styles.progress_bar}></div>
+                    <p>{currentRecords[year][1]}</p>
                 </div>)
             }
             setDataDivs(tempArray.reverse())
@@ -134,7 +179,8 @@ export default function Produciton({productionData}) {
 
     return (
         <>
-            <button onClick={()=>setadvance(prev => prev+1)}>Advance</button>
+            <button onClick={() => setadvance(prev => prev + 1)}>Advance</button>
+            <p>Date{sortedOrderedData[currentRecordIndex]}</p>
             <div className={production_styles.production_animation_container}>
                 {dataDivs}
             </div>

--- a/src/pages/production.js
+++ b/src/pages/production.js
@@ -135,25 +135,28 @@ export default function Produciton({ productionData }) {
             setCurrentRecordsDate(Object.keys(sortedOrderedData)[currentRecordIndex])
             let currentRecords = sortedOrderedData[currentRecordsDate]
             for (let year in currentRecords) {
+                console.log(currentRecords[year][1])
                 tempArray.push(<div key={`${currentRecords[year]}-${year}`} className={production_styles.yearly_row}>
                     <h2>{year}</h2>
-                    <div style={{ width: `${currentRecords[year][1] / 18886 * 100}%` }} className={production_styles.progress_bar}>
-                        {currentRecords[year][1] === 0? '': <p>{currentRecords[year][1]}</p>}
+                    <div style={{ width: `calc(${currentRecords[year][1] / 18886 * 100}%)` }} className={production_styles.progress_bar}>
+                        {currentRecords[year][1] === 0 ? '' : <p>{currentRecords[year][1]}</p>}
                     </div>
                 </div>)
             }
             setDataDivs(tempArray.reverse())
-            setCurrentRecordIndex(prev => {
-                return prev + 1
-            });
+
         }
         makeDataDivs()
-    }, [advance])
+    }, [currentRecordIndex])
 
 
 
     return (
         <>
+            <h2 className={production_styles.primary_heading}>Yearly Production Timeline Comparison</h2>
+            <p>Compare YTD production totals from back to 2018.  Adjust the slider to select the date to compare.  Broken down into 8 hour intervals.</p>
+            <hr/>
+            <h4 className={production_styles.date_header}>{currentRecordsDate}</h4>
             <input className={production_styles.date_slider} type="range" min="0" max={Object.keys(sortedOrderedData).length - 1} value={currentRecordIndex} onChange={(e) => {
                 setCurrentRecordsDate(Object.keys(sortedOrderedData)[Number(e.target.value)])
                 setCurrentRecordIndex(Number(e.target.value))
@@ -161,8 +164,10 @@ export default function Produciton({ productionData }) {
                 console.log(Object.keys(sortedOrderedData).length, currentRecordIndex, currentRecordsDate)
 
             }}></input>
-            <button onClick={() => setadvance(prev => prev + 1)}>Advance</button>
-            <p>Date{currentRecordsDate}</p>
+            <div className={production_styles.time_control_button_container}>
+                <button onClick={() => setCurrentRecordIndex(prev => prev - 1)}>&#8678;</button>
+                <button onClick={() => setCurrentRecordIndex(prev => prev + 1)}>&#8680;</button>
+            </div>
             <div className={production_styles.production_animation_container}>
                 {dataDivs}
             </div>

--- a/src/styles/production_page_styles.module.scss
+++ b/src/styles/production_page_styles.module.scss
@@ -1,5 +1,11 @@
 @use '@/styles/global_variables.scss';
 
+.date_slider{
+    width: 95%;
+    margin: 1rem auto;
+    display: block;
+}
+
 .production_animation_container {
     height: 95%;
 
@@ -8,13 +14,26 @@
         justify-content: flex-start;
         align-items: center;
         margin: 5px;
-    
-        .progress_bar {
-            margin-left: 3px;
-            height: 40px;
-            background-color: lightslategrey;
-        }
-    }
+            
+            .progress_bar {
+                min-width: max-content;
+                margin-left: 30px;
+                height: 40px;
+                background-color: lightslategrey;
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
+                border-left: 1px solid #333;
+                
+                
+                p {
+                    padding: 5px;
+                    text-shadow: 1px 1px 2px white;
+                    font-weight: 700;
+                    font-size: 1.25rem;
+                }
+            }
+       }
 
 
 }

--- a/src/styles/production_page_styles.module.scss
+++ b/src/styles/production_page_styles.module.scss
@@ -1,0 +1,20 @@
+@use '@/styles/global_variables.scss';
+
+.production_animation_container {
+    height: 95%;
+
+    .yearly_row{
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        margin: 5px;
+    
+        .progress_bar {
+            margin-left: 3px;
+            height: 40px;
+            background-color: lightslategrey;
+        }
+    }
+
+
+}

--- a/src/styles/production_page_styles.module.scss
+++ b/src/styles/production_page_styles.module.scss
@@ -1,24 +1,81 @@
 @use '@/styles/global_variables.scss';
 
+.primary_heading{
+    font-size: 1.25rem;
+    margin: 5px auto;
+    font-weight: 700;
+    font-family: global_variables.$global_fonts;
+}
+
+.primary_heading + p {
+    font-size: .75rem;
+    margin: 10px auto;
+    font-weight: 500;
+    font-family: global_variables.$global_fonts;
+}
+    .primary_heading + p + hr {
+    width: 50%;
+    margin: 15px auto;
+}
+
+
+.time_control_button_container {
+    display: flex;
+    width: 100%;
+    justify-content: center;
+    align-items: center;
+    font-family: global_variables.$global_fonts;
+    
+    button {
+        background-color: white;
+        font-size: 1.5rem;
+        padding: 0px 15px;
+        border-radius: 6px;
+        margin: 5px;
+    }
+}
+
 .date_slider{
     width: 95%;
     margin: 1rem auto;
     display: block;
 }
 
+.date_header {
+    font-family: global_variables.$global_fonts;
+    font-size: 1.35rem;
+    font-weight: 700;
+    display: block;
+    width: max-content;
+    margin: 0 auto;
+}
+
 .production_animation_container {
+    font-family: global_variables.$global_fonts;
     height: 95%;
+    width: 98%;
+    margin: 10px auto;
+    background-color: white;
+    padding: 15px;
+    border: 2px solid #222;
+    border-radius: 5px;
+    box-shadow: 2px 2px 5px #333;
 
     .yearly_row{
         display: flex;
         justify-content: flex-start;
         align-items: center;
         margin: 5px;
+
+        h2 {
+            font-size: 1rem;
+            width: 5%;
+        }
             
             .progress_bar {
-                min-width: max-content;
-                margin-left: 30px;
-                height: 40px;
+                // min-width: min-content;
+                margin-left: 5px;
+                height: 1.5rem;
                 background-color: lightslategrey;
                 display: flex;
                 align-items: center;
@@ -27,6 +84,7 @@
                 
                 
                 p {
+                    min-width: 0px;
                     padding: 5px;
                     text-shadow: 1px 1px 2px white;
                     font-weight: 700;


### PR DESCRIPTION
Initial build of production page to compare YTD production totals across the seasons.  Simply add new tables to the database (see DB for table formats) and add the new year to the list of production years being tracked (see the getServerSideProps of the production page route) and it will be included.